### PR TITLE
Add initial simulation framework modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🌐 Coherence Simulation Framework
 
-This project explores how static geometric fields—such as spirals, arcs, and dual-core shapes—can influence entropy and curvature in scalar signal propagation. The framework simulates energy-like signals diffusing through these geometries and tracks how coherence, structure, and information density evolve over time.
+This project explores how static geometric fields—such as spirals, arcs, and dual-core shapes—affect entropy and curvature during scalar signal propagation. The framework simulates energy-like signals diffusing through these geometries and tracks how coherence, structure, and information density evolve over time.
 
 ---
 
@@ -17,11 +17,17 @@ This project explores how static geometric fields—such as spirals, arcs, and d
 
 ## 📂 Project Structure
 
-├── coherence_simulation/ │ ├── geometry_fields.py # Spiral, Arc, Dual-Core masks │ ├── simulation_runner.py # Main evolution logic │ ├── metrics.py # Entropy and curvature functions │ └── visualization.py # Plotting and animation tools ├── outputs/ │ └── figures, animations ├── r_go2.ipynb # Main notebook with documentation └── README.md
-
-yaml
-Copy
-Edit
+```
+coherence_simulation/
+├── geometry_fields.py   # Spiral, Arc, Dual-Core masks
+├── simulation_runner.py # Main evolution logic
+├── metrics.py           # Entropy and curvature functions
+└── visualization.py     # Plotting helpers
+outputs/
+└── figures, animations
+r_go2.py                 # Example script
+README.md
+```
 
 ---
 
@@ -32,7 +38,7 @@ The central idea is to test whether *geometry alone*—without dynamic feedback�
 - **Entropy**: Information dispersion across the signal field
 - **Curvature**: Structural sharpness of spatial gradients
 
-These quantities help describe how “focused” or “diffuse” energy becomes within a given field shape.
+These quantities help describe how "focused" or "diffuse" energy becomes within a given field shape.
 
 ---
 
@@ -40,28 +46,24 @@ These quantities help describe how “focused” or “diffuse” energy becomes
 
 1. Install required packages:
    ```bash
-   pip install numpy matplotlib
-Run the notebook:
+   pip install -r requirements.txt
+   ```
+2. Run the example script:
+   ```bash
+   python r_go2.py
+   ```
 
-bash
-Copy
-Edit
-jupyter notebook r_go2.ipynb
-Or, run the Python script directly once modularized:
+Unit tests can be executed with:
+```bash
+pytest
+```
 
-bash
-Copy
-Edit
-python simulation_runner.py
-📈 Example Outputs
-Geometry Type	Final Distribution	Entropy Curve
-Spiral	
-Arc	
-Dual-Core	
+---
 
+📜 **License**
 
-📜 License
 This project is licensed under the MIT License — feel free to build, remix, or contribute.
 
-🤝 Acknowledgments
+🤝 **Acknowledgments**
+
 This project was developed as a personal exploration of wave-based geometry and information flow. Special thanks to the open-source community and theoretical physics inspiration.

--- a/coherence_simulation/geometry_fields.py
+++ b/coherence_simulation/geometry_fields.py
@@ -1,0 +1,25 @@
+"""Geometry field generators for the coherence simulation framework."""
+
+import numpy as np
+
+def spiral_mask(size: int, turns: int = 3) -> np.ndarray:
+    """Return a spiral mask as a 2D numpy array."""
+    y, x = np.ogrid[-1:1:complex(size), -1:1:complex(size)]
+    theta = np.arctan2(y, x)
+    radius = np.hypot(x, y)
+    spiral = np.sin(turns * theta + radius * np.pi)
+    return spiral
+
+def arc_mask(size: int, angle: float = np.pi/2) -> np.ndarray:
+    """Return an arc mask covering the given angle."""
+    y, x = np.ogrid[-1:1:complex(size), -1:1:complex(size)]
+    theta = np.arctan2(y, x)
+    mask = (np.abs(theta) < angle/2).astype(float)
+    return mask
+
+def dual_core_mask(size: int, separation: float = 0.5) -> np.ndarray:
+    """Return a dual-core mask composed of two Gaussian spots."""
+    y, x = np.ogrid[-1:1:complex(size), -1:1:complex(size)]
+    core1 = np.exp(-((x-separation)**2 + y**2)/0.1)
+    core2 = np.exp(-((x+separation)**2 + y**2)/0.1)
+    return core1 + core2

--- a/coherence_simulation/metrics.py
+++ b/coherence_simulation/metrics.py
@@ -1,0 +1,17 @@
+"""Metrics for evaluating scalar fields in the coherence simulation framework."""
+
+import numpy as np
+from scipy.ndimage import gaussian_laplace
+
+
+def entropy(field: np.ndarray) -> float:
+    """Compute Shannon entropy of a normalized field."""
+    flat = field.ravel()
+    prob = np.abs(flat) / np.sum(np.abs(flat))
+    prob = prob[prob > 0]
+    return -np.sum(prob * np.log(prob))
+
+
+def curvature(field: np.ndarray, sigma: float = 1.0) -> np.ndarray:
+    """Compute curvature using a Laplacian operator."""
+    return gaussian_laplace(field, sigma=sigma)

--- a/coherence_simulation/simulation_runner.py
+++ b/coherence_simulation/simulation_runner.py
@@ -1,0 +1,32 @@
+"""Simple scalar field simulation runner."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .metrics import entropy, curvature
+
+
+def step(field: np.ndarray, kernel: np.ndarray) -> np.ndarray:
+    """Perform one diffusion-like step with convolution."""
+    from scipy.signal import convolve2d
+
+    return convolve2d(field, kernel, mode="same", boundary="wrap")
+
+
+def run_simulation(initial: np.ndarray, steps: int = 10, dt: float = 0.1) -> list[np.ndarray]:
+    """Run a simple simulation on the initial field."""
+    kernel = np.array([[0, dt, 0], [dt, 1 - 4*dt, dt], [0, dt, 0]])
+    field = initial.copy()
+    history = [field]
+    for _ in range(steps):
+        field = step(field, kernel)
+        history.append(field)
+    return history
+
+
+def analyze(history: list[np.ndarray]) -> dict[str, list[float]]:
+    """Compute entropy and curvature over a simulation history."""
+    ent = [entropy(f) for f in history]
+    curv = [np.mean(np.abs(curvature(f))) for f in history]
+    return {"entropy": ent, "curvature": curv}

--- a/coherence_simulation/visualization.py
+++ b/coherence_simulation/visualization.py
@@ -1,0 +1,12 @@
+"""Visualization utilities for coherence simulation."""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def plot_field(field: np.ndarray, title: str = "") -> None:
+    """Plot a 2D scalar field."""
+    plt.imshow(field, cmap="viridis")
+    plt.colorbar()
+    plt.title(title)
+    plt.show()

--- a/r_go2.py
+++ b/r_go2.py
@@ -1,0 +1,19 @@
+"""Example usage of the coherence_simulation package."""
+
+import numpy as np
+
+from coherence_simulation import geometry_fields, simulation_runner, visualization
+
+
+def main():
+    size = 50
+    field = geometry_fields.spiral_mask(size)
+    history = simulation_runner.run_simulation(field, steps=20)
+    analysis = simulation_runner.analyze(history)
+
+    visualization.plot_field(history[-1], title="Final Field")
+    print("Final entropy:", analysis["entropy"][-1])
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+matplotlib
+scipy
+pytest

--- a/tests/test_geometry_fields.py
+++ b/tests/test_geometry_fields.py
@@ -1,0 +1,15 @@
+import numpy as np
+from coherence_simulation import geometry_fields
+
+def test_spiral_mask_shape():
+    mask = geometry_fields.spiral_mask(20)
+    assert mask.shape == (20, 20)
+
+def test_arc_mask_shape():
+    mask = geometry_fields.arc_mask(15)
+    assert mask.shape == (15, 15)
+
+
+def test_dual_core_mask_shape():
+    mask = geometry_fields.dual_core_mask(10)
+    assert mask.shape == (10, 10)


### PR DESCRIPTION
## Summary
- implement `coherence_simulation` package with basic modules
- provide example usage script `r_go2.py`
- clean up README
- add dependencies in `requirements.txt`
- create simple unit test for geometry mask shapes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
